### PR TITLE
Fixed title wording

### DIFF
--- a/Swarm.md
+++ b/Swarm.md
@@ -1,6 +1,6 @@
 # Codefresh | Docs
 
-# Deploy Codefresh to Microsoft Azure | ACS Swarm (Pre 1.12)
+# Use Codefresh to Build and Deploy Containers to Microsoft Azure | ACS Swarm (Pre 1.12)
 
 ## Before we begin
 


### PR DESCRIPTION
Previous wording was ambiguous. It sounded like we were deploying Codefresh on Azure, instead of deploying our own containers to Azure using Codefresh.